### PR TITLE
feat: make pwd mandatory in start tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ bun run packages/mcp-server/src/index.ts --transport http
 
 ### MCP Tools
 
-- `start`: 새 PTY 인스턴스 생성 (초기 출력 포함 즉시 반환)
+- `start`: 새 PTY 인스턴스 생성 (command와 pwd 필수, 초기 출력 포함 즉시 반환)
 - `kill`: PTY 인스턴스 종료
 - `list`: PTY 프로세스 목록 조회 (Resources 비활성화 시)
 - `read`: PTY 출력 읽기 (Resources 비활성화 시)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -160,6 +160,7 @@ Phase 1 (Infrastructure) ✅
 - ✅ **Reconnection Fix** - Support reconnection with session reuse
 - ✅ **normalize-commands Integration** - Integrated command parsing into pty-manager
 - ✅ **Test Enhancement** - Extended tests for environment variables and argument parsing
+- ✅ **Accurate pwd Setting** - Fixed issue where commands execute with mcp-pty server directory as pwd by making pwd mandatory in start tool
 
 ### In Progress
 
@@ -186,4 +187,3 @@ Phase 1 (Infrastructure) ✅
 ## Additional Plans
 
 1. Environment variable passing: Analyze what env MCP clients expect
-2. Accurate pwd setting: Fix issue where commands execute with mcp-pty server directory as pwd

--- a/packages/mcp-pty/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp-pty/src/__tests__/mcp-server.test.ts
@@ -269,7 +269,7 @@ describe("MCP Server", () => {
     test("start tool handler creates PTY", async () => {
       const { start } = createToolHandlers(server);
 
-      const result = await start({ command: "echo test" });
+      const result = await start({ command: "echo test", pwd: process.cwd() });
 
       expect(result).toBeDefined();
       expect(result.content).toBeDefined();
@@ -301,9 +301,9 @@ describe("MCP Server", () => {
       const unboundServer = factory.createServer();
       const { start } = createToolHandlers(unboundServer);
 
-      await expect(start({ command: "echo test" })).rejects.toThrow(
-        "No session bound to server",
-      );
+      await expect(
+        start({ command: "echo test", pwd: process.cwd() }),
+      ).rejects.toThrow("No session bound to server");
     });
 
     test("kill tool handler removes PTY", async () => {

--- a/packages/mcp-pty/src/tools/index.ts
+++ b/packages/mcp-pty/src/tools/index.ts
@@ -59,12 +59,20 @@ type ToolResult = {
  */
 export const createToolHandlers = (server: McpServer) => {
   return {
-    start: async ({ command }: { command: string }): Promise<ToolResult> => {
+    start: async ({
+      command,
+      pwd,
+    }: {
+      command: string;
+      pwd: string;
+    }): Promise<ToolResult> => {
       const sessionId = getBoundSessionId(server);
       const ptyManager = sessionManager.getPtyManager(sessionId);
       if (!ptyManager) throw new Error("Session not found");
-      const { processId, screen, exitCode } =
-        await ptyManager.createPty(command);
+      const { processId, screen, exitCode } = await ptyManager.createPty({
+        command,
+        cwd: pwd,
+      });
       sessionManager.addPty(sessionId, processId);
       return {
         content: [

--- a/packages/mcp-pty/src/types/index.ts
+++ b/packages/mcp-pty/src/types/index.ts
@@ -13,7 +13,10 @@ export interface McpServerConfig {
  * PTY tool input schemas
  * sessionId is optional - automatically resolved from transport connection
  */
-export const StartPtyInputSchema = z.object({ command: z.string() });
+export const StartPtyInputSchema = z.object({
+  command: z.string(),
+  pwd: z.string().describe("Working directory for the PTY process"),
+});
 
 export const KillPtyInputSchema = z.object({ processId: z.string() });
 

--- a/packages/pty-manager/src/process.ts
+++ b/packages/pty-manager/src/process.ts
@@ -47,7 +47,7 @@ export class PtyProcess {
   constructor(commandOrOptions: string | PtyOptions) {
     const options =
       typeof commandOrOptions === "string"
-        ? { command: commandOrOptions }
+        ? { command: commandOrOptions, cwd: process.cwd() }
         : commandOrOptions;
 
     this.id = nanoid();

--- a/packages/pty-manager/src/types/index.ts
+++ b/packages/pty-manager/src/types/index.ts
@@ -36,7 +36,7 @@ export interface PtyOptions {
   /** Shell command to execute (e.g., "ls -la", "echo hello && pwd") */
   command: string;
   /** Working directory */
-  cwd?: string;
+  cwd: string;
   /** Environment variable overrides */
   env?: Record<string, string>;
   /** Whether to auto-dispose on program exit (for interactive programs) */


### PR DESCRIPTION
## Summary
- Added pwd parameter to StartPtyInputSchema as mandatory
- Made cwd mandatory in PtyOptions  
- Updated start tool handler to use pwd for cwd
- Set default cwd in PtyProcess for string inputs
- Updated tests and documentation

This fixes the issue where commands were executing in the mcp-pty server directory instead of the intended working directory.