### PR TITLE
fix: remove label from automated PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           bun run build
 
       - name: Publish to NPM
-        if: ${{ github.event.inputs.dry_run != 'true' }}
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -70,12 +70,13 @@ jobs:
           npm publish --access public
       
       - name: Dry run - Skip NPM publish
-        if: ${{ github.event.inputs.dry_run == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
         run: |
-          echo "Dry run mode - skipping NPM publish"
+          echo "🔍 Dry run mode - skipping NPM publish"
           echo "Would publish version ${{ steps.version.outputs.new_version }}"
 
       - name: Create version bump PR
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
         run: |
           BRANCH_NAME="release/v${{ steps.version.outputs.new_version }}"
           git checkout -b $BRANCH_NAME
@@ -88,8 +89,15 @@ jobs:
           gh pr merge $BRANCH_NAME --auto --squash --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Dry run - Skip PR creation
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
+        run: |
+          echo "🔍 Dry run mode - skipping version bump PR"
+          echo "Would create PR for version ${{ steps.version.outputs.new_version }}"
 
       - name: Sync version to develop
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
         run: |
           sleep 10
           git fetch origin main
@@ -99,6 +107,7 @@ jobs:
           git push origin develop
 
       - name: Create GitHub Release
+        if: ${{ github.event_name == 'push' || github.event.inputs.dry_run != 'true' }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove non-existent 'release' label that was causing workflow failure