### PR TITLE
fix(pty): handle empty input gracefully with warning (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- PTY input handling for empty strings and newline characters (#15)
+  - Empty input now returns a warning message instead of throwing ArrayBufferView error
+  - Added proper validation and graceful handling for edge cases
+  - Updated return types to include optional warning field
+
+### Added
+- Comprehensive test coverage for empty input and newline handling scenarios
+- Warning system for edge cases in PTY input operations
+
+### Changed
+- Enhanced PTY write method with better error handling and user feedback
+- Updated MCP tool schemas to support warning responses
+
+---
+
+## [Previous Versions]
+
+*Initial release with basic PTY functionality*

--- a/packages/mcp-pty/src/types/index.ts
+++ b/packages/mcp-pty/src/types/index.ts
@@ -82,6 +82,10 @@ export const WriteInputOutputSchema = z.object({
     .number()
     .nullable()
     .describe("Process exit code (null if still running)"),
+  warning: z
+    .string()
+    .optional()
+    .describe("Warning message for edge cases (e.g., empty input)"),
 });
 
 /**

--- a/packages/pty-manager/src/__tests__/pty-process.test.ts
+++ b/packages/pty-manager/src/__tests__/pty-process.test.ts
@@ -201,6 +201,43 @@ test("PtyProcess write control characters", async () => {
   expect(result.cursor).toHaveProperty("x");
 });
 
+test("PtyProcess write empty string should not throw", async () => {
+  const pty = new PtyProcess("cat");
+  ptys.push(pty);
+  await pty.ready();
+
+  // Empty string should be handled gracefully with warning
+  const result = await pty.write("", 100);
+  expect(result.screen).toBeDefined();
+  expect(result.cursor).toHaveProperty("x");
+  expect(result.exitCode).toBeNull();
+  expect(result.warning).toBe("Empty input ignored - use '\\n' for Enter key");
+});
+
+test("PtyProcess write newline only should work", async () => {
+  const pty = new PtyProcess("cat");
+  ptys.push(pty);
+  await pty.ready();
+
+  // Newline only should work for Enter key simulation
+  const result = await pty.write("\n", 100);
+  expect(result.screen).toBeDefined();
+  expect(result.cursor).toHaveProperty("x");
+  expect(result.exitCode).toBeNull();
+});
+
+test("PtyProcess write multiple newlines should work", async () => {
+  const pty = new PtyProcess("cat");
+  ptys.push(pty);
+  await pty.ready();
+
+  // Multiple newlines should work
+  const result = await pty.write("\n\n\n", 200);
+  expect(result.screen).toBeDefined();
+  expect(result.cursor).toHaveProperty("x");
+  expect(result.exitCode).toBeNull();
+});
+
 // ============================================================================
 // Buffer Capture Tests
 // ============================================================================

--- a/packages/pty-manager/src/process.ts
+++ b/packages/pty-manager/src/process.ts
@@ -180,9 +180,22 @@ export class PtyProcess {
     screen: string;
     cursor: { x: number; y: number };
     exitCode: number | null;
+    warning?: string;
   }> {
     if (this.status === "terminated" || this.status === "terminating") {
       throw new Error(`PTY ${this.id} is not active`);
+    }
+
+    // Handle empty input gracefully with warning
+    if (data.length === 0) {
+      logger.warn(`PTY ${this.id}: Empty input received, ignoring`);
+      await Bun.sleep(waitMs);
+      return {
+        screen: this.getScreenContent(),
+        cursor: this.getCursorPosition(),
+        exitCode: this.exitCode,
+        warning: "Empty input ignored - use '\\n' for Enter key",
+      };
     }
 
     // Security checks


### PR DESCRIPTION
## Summary
- Fix PTY input handling for empty strings and newline characters that caused ArrayBufferView errors
- Add graceful handling with warning messages instead of throwing exceptions
- Update MCP tool schemas to support optional warning field in responses
- Add comprehensive test coverage for edge cases

## Changes
- **PtyProcess.write()**: Added empty input validation with warning response
- **MCP Types**: Updated WriteInputOutputSchema to include optional warning field
- **Tests**: Added test cases for empty string, newline, and multiple newline inputs
- **Documentation**: Added CHANGELOG.md for tracking notable changes

## Fixes
- Resolves #15: PTY Input Handling Issues with Empty Input and Newline Characters
- Empty input now returns "Empty input ignored - use '\\n' for Enter key" warning
- Newline characters work properly for command execution
- No more TypeError for valid terminal input

## Testing
- All existing tests pass
- New test cases added for edge cases
- Verified warning message handling and proper error recovery