### PR TITLE
fix: backmerge main to develop to resolve duplicate commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,8 @@ Then push to origin.
 - **Commit Message Format**: English only. Include issue references (e.g., `Fixes #30`). Focus on "why" not "what".
 - **AgentLogs Before PR**: Write AgentLog in docs/agentlogs/ following howto.md before creating PR. Ensures documentation of decisions, issues, solutions.
 - **PR Description**: Include AgentLog reference, key changes, impact. Use English.
+- **Agent Identity**: MUST declare specific agent name in all GitHub PRs/comments/reviews. Use exact model names: Sonnet4.5/Haiku4.5/GLM4.6/KimiK2/GrokCodeFast1 etc. "TypeScript expert/git" not valid. Ask user if unclear.
+- **Communication Style**: All GitHub PRs/comments/issues MUST be in English. Sacrifice grammar for concision. Use user's language only in direct responses.
 
 #### Response Style Guide (Prevent Repeat Mistakes)
 


### PR DESCRIPTION
Agent Identity: GLM4.6

## Summary

This PR fixes a duplicate commit situation that was accidentally created:

- Commit `58aba97` was mistakenly created on `main` with minimal AGENTS.md changes
- Commit `773d391` was then created on `develop` with the same AGENTS.md changes plus many other improvements
- This created duplicate commits that need to be resolved

## Changes

- Backmerges the `main` branch commit `58aba97` to `develop`
- This will bring the main commit to develop so the duplicate can be resolved
- Following gitflow principles by creating a PR from main to develop

## Impact

- Resolves the duplicate commit issue
- Allows proper cleanup of the duplicate AGENTS.md changes
- Maintains clean git history following gitflow methodology

## Next Steps

After this PR is merged:
1. The duplicate commits can be resolved on develop
2. Clean history can be maintained
3. Future merges to main will be properly synchronized