### PR TITLE
refactor: remove redundant outputBuffer delegation

### DIFF
--- a/packages/mcp-pty/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp-pty/src/__tests__/mcp-server.test.ts
@@ -64,7 +64,7 @@ describe("MCP Server", () => {
         if (!pty) throw new Error("PTY not found");
 
         expect(pty).toBeDefined();
-        expect(typeof pty.getOutputBuffer()).toBe("string");
+        expect(typeof pty.getScreenContent()).toBe("string");
       });
     });
 
@@ -217,8 +217,8 @@ describe("MCP Server", () => {
         if (!content?.text) throw new Error("content.text is undefined");
 
         const parsed = JSON.parse(content.text);
-        expect(parsed).toHaveProperty("output");
-        expect(typeof parsed.output).toBe("string");
+        expect(parsed).toHaveProperty("screen");
+        expect(typeof parsed.screen).toBe("string");
 
         ptyManager.dispose();
       });

--- a/packages/mcp-pty/src/resources/index.ts
+++ b/packages/mcp-pty/src/resources/index.ts
@@ -82,8 +82,9 @@ export const createResourceHandlers = (server: McpServer) => ({
     if (!ptyManager) throw new Error("Session not found");
     const pty = ptyManager.getPty(processId);
     if (!pty) throw new Error("PTY process not found");
-    const output = pty.getOutputBuffer();
-    return { contents: [{ uri: uri.href, text: JSON.stringify({ output }) }] };
+    // Get current screen content from xterm buffer
+    const screen = pty.getScreenContent();
+    return { contents: [{ uri: uri.href, text: JSON.stringify({ screen }) }] };
   },
 });
 

--- a/packages/pty-manager/src/__tests__/pty-manager.test.ts
+++ b/packages/pty-manager/src/__tests__/pty-manager.test.ts
@@ -373,8 +373,8 @@ test("PtyProcess autoDisposeOnExit triggers cleanup on process exit", async () =
 test("PtyProcess onOutput callback receives output data", async () => {
   await withTestPtyProcess("echo hello", async (pty) => {
     await Bun.sleep(100);
-    const buffer = pty.getOutputBuffer();
-    expect(buffer.length).toBeGreaterThan(0);
+    const screen = pty.getScreenContent();
+    expect(screen.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/pty-manager/src/__tests__/pty-process.test.ts
+++ b/packages/pty-manager/src/__tests__/pty-process.test.ts
@@ -241,14 +241,14 @@ test("PtyProcess captureBuffer returns array of lines", async () => {
   });
 });
 
-test("PtyProcess getOutputBuffer accumulates output", async () => {
+test("PtyProcess getScreenContent captures current screen", async () => {
   await withTestPtyProcess("echo accumulate", async (pty) => {
     await pty.ready();
     await Bun.sleep(200);
 
-    const output = pty.getOutputBuffer();
-    expect(output.length).toBeGreaterThan(0);
-    expect(output).toContain("accumulate");
+    const screen = pty.getScreenContent();
+    expect(screen.length).toBeGreaterThan(0);
+    expect(screen).toContain("accumulate");
   });
 });
 


### PR DESCRIPTION
## Summary
- Remove redundant `outputBuffer` field from PtyProcess since xterm/headless already manages terminal rendering and buffering
- Delegate buffer management entirely to xterm - eliminates duplicate memory overhead
- Public API simplified: single source of truth via `getScreenContent()`

## Changes
- **PtyProcess**: Remove `outputBuffer` field, `getOutputBuffer()` method; make `getScreenContent()` public
- **toPromise()**: Return final screen state instead of raw history
- **MCP Resource**: `processOutput` handler uses `getScreenContent()` instead of raw buffer
- **Tests**: Updated to use `getScreenContent()`

## Impact
- Reduces memory footprint (no redundant string accumulation)
- Simplifies API surface (one buffer source)
- Fully leverages xterm/headless capabilities

## Related to #22
This is the first step toward performance optimization (Phase 6.1) - removing unnecessary memory overhead.

---
*Agent: Claude Haiku 4.5*