### PR TITLE
fix: correct package name in mcp-pty README

### DIFF
--- a/docs/agentlogs/025-fix-readme-package-name.md
+++ b/docs/agentlogs/025-fix-readme-package-name.md
@@ -1,0 +1,19 @@
+# Fix README Package Name
+
+**AgentInfo**: Haiku 4.5
+
+**Date**: 2025-10-20
+
+## Summary
+Fixed incorrect package name references in mcp-pty README documentation.
+
+## Changes
+- Updated README title from `mcp-pty-server` to `mcp-pty`
+- Updated installation command to use correct package name `mcp-pty`
+
+## Files Modified
+- `packages/mcp-pty/README.md`
+
+## Result
+- Created PR #48 against develop branch
+- Ensures npm package documentation matches actual package name

--- a/packages/mcp-pty/README.md
+++ b/packages/mcp-pty/README.md
@@ -1,11 +1,11 @@
-# mcp-pty-server
+# mcp-pty
 
 MCP (Model Context Protocol) server for PTY session management with Bun runtime.
 
 ## Installation
 
 ```bash
-bun add mcp-pty-server
+bun add mcp-pty
 ```
 
 ## Usage


### PR DESCRIPTION
Fixes incorrect package name references in README that showed 'mcp-pty-server' instead of 'mcp-pty'. Ensures documentation matches the actual npm package name.