### PR TITLE
chore: add commitlint enforcement with English-only validation

### DIFF
--- a/docs/agentlogs/026-commitlint-enforcement-setup.md
+++ b/docs/agentlogs/026-commitlint-enforcement-setup.md
@@ -1,0 +1,49 @@
+# Commitlint Enforcement Setup
+
+**Agent:** Haiku 4.5
+
+## Objective
+Enforce Conventional Commits with English-only enforcement via commitlint + husky. Prevent Korean/Chinese/Japanese characters in commit messages at pre-commit stage.
+
+## Issues Identified
+1. No automated commit message validation in existing hooks
+2. Release workflow uses automated commits with no linting
+3. Manual commits lack format enforcement, risk inconsistency
+4. Future contributors might bypass conventions
+
+## Solution: Commitlint + Husky Integration
+
+### Implementation Steps
+
+1. **Installed Dependencies**
+   - `@commitlint/cli@20.1.0`
+   - `@commitlint/config-conventional@20.0.0`
+
+2. **Created commitlint.config.js**
+   - Extended `@commitlint/config-conventional` base rules
+   - Added custom `english-only` plugin rule
+   - Enforces no non-ASCII characters (regex: `/[^\x00-\x7F]/`)
+   - Validates commit type enum: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
+   - Header max length: 100 chars
+
+3. **Created .husky/commit-msg Hook**
+   - Executes `commitlint --edit $1` on every commit attempt
+   - Fails pre-commit if violations detected
+   - Husky v9 compatible (removed deprecated shebang for v10 forward compatibility)
+
+4. **Validated with Korean Test**
+   - Attempted commit: `test: 한글 커밋 테스트`
+   - Result: ✖ Correctly rejected with message: "Commit message MUST be in English only. Non-ASCII characters detected."
+
+### Test Results
+- English commits: ✅ Pass (`chore: add commitlint...`)
+- Korean commits: ✅ Blocked (non-ASCII detection works)
+
+## Key Findings
+- Custom commitlint plugins work for domain-specific validation (non-ASCII check)
+- Bun.YAML sufficient for workflow validation (no external yaml package needed)
+- Had to rebase on latest develop (prior release workflow refactor conflicts)
+
+## Next Steps
+1. Push to remote
+2. Merge enables commitlint enforcement for all future commits


### PR DESCRIPTION
## Summary
- Add commitlint with Conventional Commits + custom English-only plugin (rejects non-ASCII)
- Fix YAML indentation inconsistency in release.yml (92-133: 5-space → 4-space)
- Secure GitHub Actions variable handling in automated commits

**Agent:** Haiku 4.5

## Changes
1. commitlint.config.js: Custom plugin for non-ASCII detection
2. .husky/commit-msg: Pre-commit hook for validation
3. .github/workflows/release.yml: Variable extraction + YAML schema fix
4. docs/agentlogs/025-commitlint-enforcement-setup.md: Implementation details

## Test Results
- Korean commit test: ✅ Blocked
- YAML validation: ✅ 4/4 workflows pass
- Release automation: ✅ Commits pass linting

**AgentLog:** docs/agentlogs/025-commitlint-enforcement-setup.md