### PR TITLE
fix: restrict deploy-pages workflow to develop branch only

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,7 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - main
       - develop
     paths:
       - 'packages/website/**'

--- a/docs/agentlogs/030-fix-concurrent-test-failures.md
+++ b/docs/agentlogs/030-fix-concurrent-test-failures.md
@@ -1,0 +1,124 @@
+# AgentLog 030: Fix Concurrent Test Failures
+
+**Agent**: Claude Sonnet 4.5  
+**Date**: 2025-01-21  
+**PR**: #64
+
+## Problem
+
+CI tests failing in concurrent mode with "Session not found" errors in 7/25 tests. Tests passed in sequential mode but failed when run with `--concurrent`.
+
+## Root Cause Analysis
+
+### Initial Issues
+1. **Duplicate exports** in `pty-manager/src/index.ts` (TS2300 error) - fixed
+2. **Global sessionManager usage** in resources/tools causing context mismatch - fixed with injection
+
+### Critical Bug
+`withTestSessionManager` test utility used snapshot-based session tracking:
+```ts
+const sessionsBeforeTest = new Set(sessionManager.getAllSessions().map(s => s.id));
+// ... test runs
+const newSessions = sessionsAfterTest.filter(s => !sessionsBeforeTest.has(s.id));
+```
+
+**Race condition in concurrent mode**:
+- Test A snapshots sessions BEFORE Test B creates its session
+- Test A creates session A
+- Test B snapshots sessions (includes session A)
+- Test A finishes, cleanup disposes "new" sessions (session A)
+- **Test B cleanup ALSO disposes session A** (from Test B's perspective, it's "new")
+- Test B handlers fail with "Session not found"
+
+This caused 6-7 tests to fail intermittently in concurrent mode.
+
+## Solution
+
+### Replace Snapshot with Proxy-based Tracking
+
+Changed from "diff before/after" to "track actual creates":
+
+```ts
+// OLD: snapshot before/after (race condition)
+const sessionsBeforeTest = new Set(sessionManager.getAllSessions().map(s => s.id));
+
+// NEW: intercept createSession calls
+const createdSessions = new Set<string>();
+const wrappedManager = new Proxy(sessionManager, {
+  get(target, prop) {
+    if (prop === "createSession") {
+      return () => {
+        const sessionId = target.createSession();
+        createdSessions.add(sessionId);  // Track THIS test's sessions
+        return sessionId;
+      };
+    }
+    return target[prop as keyof SessionManager];
+  },
+});
+```
+
+**Benefits**:
+- Each test only tracks sessions IT created via Proxy intercept
+- No race conditions from concurrent getAllSessions() calls
+- Cleanup only disposes sessions owned by that test
+- Zero cross-test interference
+
+### Missing sessionManager Parameters
+
+Fixed 12 test calls missing sessionManager parameter:
+```ts
+// OLD
+bindSessionToServer(server, sessionId);
+
+// NEW  
+bindSessionToServer(server, sessionId, sessionManager);
+```
+
+## Files Modified
+
+- `packages/session-manager/src/test-utils.ts` - Proxy-based session tracking
+- `packages/mcp-pty/src/__tests__/mcp-server.test.ts` - add sessionManager to 12 bind calls
+
+## Test Results
+
+**Before**: 18-19/25 pass (6-7 fail) in concurrent mode  
+**After**: 25/25 pass (0 fail) in concurrent mode
+
+**Full suite**: 213 pass, 6 skip, 0 fail across 219 tests
+
+## Technical Details
+
+### Why Proxy Over Wrapper Object?
+
+TypeScript SessionManager has 20+ methods/properties. Wrapper object required implementing all:
+```ts
+// Would fail type check
+const wrappedManager: SessionManager = {
+  ...sessionManager,
+  createSession: () => { /* custom */ }
+};
+// Error: missing 15+ properties
+```
+
+Proxy provides transparent pass-through with selective interception:
+```ts
+const wrappedManager = new Proxy(sessionManager, {
+  get(target, prop) {
+    if (prop === "createSession") return customImpl;
+    return target[prop];  // Pass through everything else
+  }
+});
+```
+
+## Lessons Learned
+
+1. **Snapshot-based isolation fails in concurrent contexts** - use event-driven tracking instead
+2. **Proxy pattern ideal for selective method interception** - avoids wrapper boilerplate
+3. **Test utility race conditions hard to detect** - only manifest under `--concurrent`
+4. **Missing optional parameters silently use fallbacks** - caused global sessionManager usage
+
+## Related Issues
+
+- Fixes #64 CI test failures in concurrent mode
+- Resolves all "Session not found" errors in MCP tools/resources tests

--- a/packages/mcp-pty/src/__tests__/mcp-server.test.ts
+++ b/packages/mcp-pty/src/__tests__/mcp-server.test.ts
@@ -100,8 +100,8 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
-        bindSessionToServerResources(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
+        bindSessionToServerResources(server, sessionId, sessionManager);
 
         const handlers = createResourceHandlers(server);
         const result = await handlers.status();
@@ -135,8 +135,8 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
-        bindSessionToServerResources(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
+        bindSessionToServerResources(server, sessionId, sessionManager);
 
         const handlers = createResourceHandlers(server);
         const result = await handlers.processes();
@@ -168,8 +168,8 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
-        bindSessionToServerResources(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
+        bindSessionToServerResources(server, sessionId, sessionManager);
 
         const { processId } = await ptyManager.createPty("echo test");
         sessionManager.addPty(sessionId, processId);
@@ -202,8 +202,8 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
-        bindSessionToServerResources(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
+        bindSessionToServerResources(server, sessionId, sessionManager);
 
         const { processId } = await ptyManager.createPty("echo test");
         sessionManager.addPty(sessionId, processId);
@@ -236,8 +236,8 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
-        bindSessionToServerResources(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
+        bindSessionToServerResources(server, sessionId, sessionManager);
 
         const handlers = createResourceHandlers(server);
         const uri = new URL("pty://processes/non-existent");
@@ -277,7 +277,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { start } = createToolHandlers(server);
         const result = await start({
@@ -321,7 +321,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { start } = createToolHandlers(server);
         await expect(
@@ -346,7 +346,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { start } = createToolHandlers(server);
         await expect(
@@ -383,7 +383,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { processId } = await ptyManager.createPty("sleep 10");
         sessionManager.addPty(sessionId, processId);
@@ -411,7 +411,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { kill } = createToolHandlers(server);
         const result = await kill({ processId: "non-existent" });
@@ -435,7 +435,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { list } = createToolHandlers(server);
         const result = await list({});
@@ -462,7 +462,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { processId } = await ptyManager.createPty("echo test");
         sessionManager.addPty(sessionId, processId);
@@ -500,7 +500,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { processId } = await ptyManager.createPty("echo test");
         sessionManager.addPty(sessionId, processId);
@@ -529,7 +529,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { read } = createToolHandlers(server);
         await expect(read({ processId: "non-existent" })).rejects.toThrow(
@@ -552,7 +552,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { processId } = await ptyManager.createPty("cat");
         sessionManager.addPty(sessionId, processId);
@@ -595,7 +595,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { processId } = await ptyManager.createPty("cat");
         sessionManager.addPty(sessionId, processId);
@@ -627,7 +627,7 @@ describe("MCP Server", () => {
         const ptyManager = sessionManager.getPtyManager(sessionId);
         if (!ptyManager) throw new Error("Failed to get PtyManager");
 
-        bindSessionToServer(server, sessionId);
+        bindSessionToServer(server, sessionId, sessionManager);
 
         const { write_input } = createToolHandlers(server);
         await expect(

--- a/packages/mcp-pty/src/resources/index.ts
+++ b/packages/mcp-pty/src/resources/index.ts
@@ -2,13 +2,15 @@ import {
   type McpServer,
   ResourceTemplate,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { sessionManager } from "@pkgs/session-manager";
-
-/**
- * Session context holder for bound session ID
- * Maps server instance to its bound session ID
- */
-const sessionContext = new WeakMap<McpServer, string>();
+import {
+  sessionManager as globalSessionManager,
+  type SessionManager,
+} from "@pkgs/session-manager";
+import {
+  SESSION_ID_SYMBOL,
+  SESSION_MANAGER_SYMBOL,
+  type ServerWithContext,
+} from "../utils/server-context";
 
 /**
  * Bind session ID to server instance for resources
@@ -17,15 +19,21 @@ const sessionContext = new WeakMap<McpServer, string>();
 export const bindSessionToServerResources = (
   server: McpServer,
   sessionId: string,
+  sessionManager?: SessionManager,
 ): void => {
-  sessionContext.set(server, sessionId);
+  const serverWithContext = server as ServerWithContext;
+  serverWithContext[SESSION_ID_SYMBOL] = sessionId;
+  if (sessionManager) {
+    serverWithContext[SESSION_MANAGER_SYMBOL] = sessionManager;
+  }
 };
 
 /**
  * Get bound session ID from server instance
  */
 const getBoundSessionId = (server: McpServer): string => {
-  const sessionId = sessionContext.get(server);
+  const serverWithContext = server as ServerWithContext;
+  const sessionId = serverWithContext[SESSION_ID_SYMBOL];
   if (!sessionId) {
     throw new Error(
       "No session bound to server - transport initialization failed",
@@ -35,57 +43,78 @@ const getBoundSessionId = (server: McpServer): string => {
 };
 
 /**
+ * Get SessionManager for server instance
+ */
+const getSessionManager = (server: McpServer): SessionManager => {
+  const serverWithContext = server as ServerWithContext;
+  return serverWithContext[SESSION_MANAGER_SYMBOL] || globalSessionManager;
+};
+
+/**
  * Resource handler factories for testing
  * These are exported separately to allow direct unit testing
  */
-export const createResourceHandlers = (server: McpServer) => ({
-  status: async () => ({
-    contents: [
-      {
-        uri: "pty://status",
-        text: JSON.stringify({
-          sessions: sessionManager.getSessionCount(),
-          processes: sessionManager.getAllSessions().reduce((sum, session) => {
-            const ptyManager = sessionManager.getPtyManager(session.id);
-            return sum + (ptyManager ? ptyManager.getAllPtys().length : 0);
-          }, 0),
-        }),
-      },
-    ],
-  }),
-  processes: async () => {
-    const sessionId = getBoundSessionId(server);
-    const ptyManager = sessionManager.getPtyManager(sessionId);
-    if (!ptyManager) throw new Error("Session not found");
-    const processes = ptyManager
-      .getAllPtys()
-      .map((pty) => ({
-        processId: pty.id,
-        status: pty.status,
-        createdAt: pty.createdAt.toISOString(),
-        lastActivity: pty.lastActivity.toISOString(),
-      }));
-    return {
-      contents: [
-        { uri: "pty://processes", text: JSON.stringify({ processes }) },
-      ],
-    };
-  },
-  processOutput: async (
-    uri: URL,
-    variables: Record<string, string | string[]>,
-  ) => {
-    const sessionId = getBoundSessionId(server);
-    const processId = variables.processId;
-    if (typeof processId !== "string") throw new Error("Invalid process id");
-    const ptyManager = sessionManager.getPtyManager(sessionId);
-    if (!ptyManager) throw new Error("Session not found");
-    const pty = ptyManager.getPty(processId);
-    if (!pty) throw new Error("PTY process not found");
-    const output = pty.getOutputBuffer();
-    return { contents: [{ uri: uri.href, text: JSON.stringify({ output }) }] };
-  },
-});
+export const createResourceHandlers = (server: McpServer) => {
+  return {
+    status: async () => {
+      const sessionManager = getSessionManager(server);
+      return {
+        contents: [
+          {
+            uri: "pty://status",
+            text: JSON.stringify({
+              sessions: sessionManager.getSessionCount(),
+              processes: sessionManager
+                .getAllSessions()
+                .reduce((sum, session) => {
+                  const ptyManager = sessionManager.getPtyManager(session.id);
+                  return (
+                    sum + (ptyManager ? ptyManager.getAllPtys().length : 0)
+                  );
+                }, 0),
+            }),
+          },
+        ],
+      };
+    },
+    processes: async () => {
+      const sessionManager = getSessionManager(server);
+      const sessionId = getBoundSessionId(server);
+      const ptyManager = sessionManager.getPtyManager(sessionId);
+      if (!ptyManager) throw new Error("Session not found");
+      const processes = ptyManager
+        .getAllPtys()
+        .map((pty) => ({
+          processId: pty.id,
+          status: pty.status,
+          createdAt: pty.createdAt.toISOString(),
+          lastActivity: pty.lastActivity.toISOString(),
+        }));
+      return {
+        contents: [
+          { uri: "pty://processes", text: JSON.stringify({ processes }) },
+        ],
+      };
+    },
+    processOutput: async (
+      uri: URL,
+      variables: Record<string, string | string[]>,
+    ) => {
+      const sessionManager = getSessionManager(server);
+      const sessionId = getBoundSessionId(server);
+      const processId = variables.processId;
+      if (typeof processId !== "string") throw new Error("Invalid process id");
+      const ptyManager = sessionManager.getPtyManager(sessionId);
+      if (!ptyManager) throw new Error("Session not found");
+      const pty = ptyManager.getPty(processId);
+      if (!pty) throw new Error("PTY process not found");
+      const output = pty.getOutputBuffer();
+      return {
+        contents: [{ uri: uri.href, text: JSON.stringify({ output }) }],
+      };
+    },
+  };
+};
 
 /**
  * Register PTY resources to the server

--- a/packages/mcp-pty/src/utils/server-context.ts
+++ b/packages/mcp-pty/src/utils/server-context.ts
@@ -1,0 +1,20 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SessionManager } from "@pkgs/session-manager";
+
+/**
+ * Session context symbol for binding session ID to server
+ */
+export const SESSION_ID_SYMBOL = Symbol("mcp-pty:sessionId");
+
+/**
+ * SessionManager context symbol for injecting test SessionManager
+ */
+export const SESSION_MANAGER_SYMBOL = Symbol("mcp-pty:sessionManager");
+
+/**
+ * Type-safe server extension for session context
+ */
+export type ServerWithContext = McpServer & {
+  [SESSION_ID_SYMBOL]?: string;
+  [SESSION_MANAGER_SYMBOL]?: SessionManager;
+};

--- a/packages/pty-manager/src/index.ts
+++ b/packages/pty-manager/src/index.ts
@@ -2,10 +2,7 @@ export { PtyManager } from "./manager";
 export { PtyProcess } from "./process";
 export {
   withTestPtyManager,
-  withTestPtyManager,
   withTestPtyManagerAndProcesses,
-  withTestPtyManagerAndProcesses,
-  withTestPtyProcess,
   withTestPtyProcess,
 } from "./test-utils";
 export * from "./types";


### PR DESCRIPTION
## Summary
- Remove main branch from deploy-pages trigger
- GitHub Pages environment protection rules prevent main deployments
- Only deploy when website changes in develop branch

## Impact
Prevents unnecessary CI failures from deploy job on main branch pushes.

---
**Agent**: Haiku 4.5