### PR TITLE
fix: Windows SSH CRLF support and tool descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: wait for main PR merge before creating GitHub Release (#54)
 
 ### Fixed
+- fix: upgrade bun-pty to 0.4.4 and clarify Windows SSH CRLF requirement
 - fix: remove non-existent release label from workflow (#53)
 - fix: adapt release workflow for protected develop branch (#51)
+
+### Changed
+- refactor: concisely rewrite all tool/resource descriptions for clarity (50-60% reduction)
 
 ### Miscellaneous Tasks
 - chore: bump version to 0.5.2 (#52)

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "@sindresorhus/is": "^7.1.0",
         "@xterm/addon-serialize": "^0.13.0",
         "@xterm/headless": "^5.5.0",
-        "@zenyr/bun-pty": "^0.4.3",
+        "@zenyr/bun-pty": "^0.4.4",
         "consola": "^3.4.2",
       },
       "peerDependencies": {
@@ -59,7 +59,7 @@
         "@pkgs/pty-manager": "workspace:*",
         "@pkgs/session-manager": "workspace:*",
         "@xterm/headless": "^5.5.0",
-        "@zenyr/bun-pty": "^0.4.3",
+        "@zenyr/bun-pty": "^0.4.4",
         "consola": "^3.4.2",
         "fetch-to-node": "^2.1.0",
         "hono": "^4.9.10",
@@ -88,7 +88,7 @@
         "@pkgs/logger": "workspace:*",
         "@pkgs/normalize-commands": "workspace:*",
         "@xterm/headless": "^5.5.0",
-        "@zenyr/bun-pty": "^0.4.3",
+        "@zenyr/bun-pty": "^0.4.4",
         "consola": "^3.4.2",
         "nanoid": "^5.1.6",
         "strip-ansi": "^7.1.2",
@@ -638,11 +638,17 @@
 
     "@commitlint/config-validator/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
+    "@pkgs/experiments/@zenyr/bun-pty": ["@zenyr/bun-pty@0.4.4", "", { "optionalDependencies": { "@zenyr/bun-pty-darwin-arm64": "0.4.4", "@zenyr/bun-pty-darwin-x64": "0.4.4", "@zenyr/bun-pty-linux-arm64": "0.4.4", "@zenyr/bun-pty-linux-x64": "0.4.4", "@zenyr/bun-pty-win32-x64": "0.4.4" } }, "sha512-XtuHDNH5+7ggg9I44heYdnn2kW96+b9uxaC2q6hSyzrhQHSGq+82M07u8H3SokMCb/4Si1Rld5taKNQ3xM+Kxw=="],
+
+    "@pkgs/pty-manager/@zenyr/bun-pty": ["@zenyr/bun-pty@0.4.4", "", { "optionalDependencies": { "@zenyr/bun-pty-darwin-arm64": "0.4.4", "@zenyr/bun-pty-darwin-x64": "0.4.4", "@zenyr/bun-pty-linux-arm64": "0.4.4", "@zenyr/bun-pty-linux-x64": "0.4.4", "@zenyr/bun-pty-win32-x64": "0.4.4" } }, "sha512-XtuHDNH5+7ggg9I44heYdnn2kW96+b9uxaC2q6hSyzrhQHSGq+82M07u8H3SokMCb/4Si1Rld5taKNQ3xM+Kxw=="],
+
     "body-parser/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "mcp-pty/@zenyr/bun-pty": ["@zenyr/bun-pty@0.4.4", "", { "optionalDependencies": { "@zenyr/bun-pty-darwin-arm64": "0.4.4", "@zenyr/bun-pty-darwin-x64": "0.4.4", "@zenyr/bun-pty-linux-arm64": "0.4.4", "@zenyr/bun-pty-linux-x64": "0.4.4", "@zenyr/bun-pty-win32-x64": "0.4.4" } }, "sha512-XtuHDNH5+7ggg9I44heYdnn2kW96+b9uxaC2q6hSyzrhQHSGq+82M07u8H3SokMCb/4Si1Rld5taKNQ3xM+Kxw=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -650,7 +656,37 @@
 
     "@commitlint/config-validator/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
+    "@pkgs/experiments/@zenyr/bun-pty/@zenyr/bun-pty-darwin-arm64": ["@zenyr/bun-pty-darwin-arm64@0.4.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+tIBa2trf681O0ttftbarFEZuXOKOLrmplD6/AYKc87TCrp7JQrLVu0Slly+4Ci8tWYiE3MGTJGBhmPSTjLKIQ=="],
+
+    "@pkgs/experiments/@zenyr/bun-pty/@zenyr/bun-pty-darwin-x64": ["@zenyr/bun-pty-darwin-x64@0.4.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-tbssenRokNls193hCSywpDwH0IpYfx8FkiDtm6u7i2sphNw6ktGftzQHH/021pWjZNVdYA75YhlfZrIGdhjHow=="],
+
+    "@pkgs/experiments/@zenyr/bun-pty/@zenyr/bun-pty-linux-arm64": ["@zenyr/bun-pty-linux-arm64@0.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-kXTeEWZrjRn2jGGnxTrYnZSJ6ZRKTiR7otK7SlmVP+pa1OtZs5J77VG93/wWq2gpTAL7Bs4vNMjEj5A6UaJG7A=="],
+
+    "@pkgs/experiments/@zenyr/bun-pty/@zenyr/bun-pty-linux-x64": ["@zenyr/bun-pty-linux-x64@0.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Vlxkvlfcg8BWDvChvJbN4N3lG7z08f+24d2jvcfx/guRz5w1qjvHfMGWvGj2DtbzIBDjXO0CaKKzdN/T2ZxSqA=="],
+
+    "@pkgs/experiments/@zenyr/bun-pty/@zenyr/bun-pty-win32-x64": ["@zenyr/bun-pty-win32-x64@0.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-esZqEjPHPWRfAd/IZNaC4mptJ2HFdPXJQPUZVIdrwxEumL7NRoQZXVrlO7MRSO2Jrjqgna4IuQIvOKvCwJNMrg=="],
+
+    "@pkgs/pty-manager/@zenyr/bun-pty/@zenyr/bun-pty-darwin-arm64": ["@zenyr/bun-pty-darwin-arm64@0.4.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+tIBa2trf681O0ttftbarFEZuXOKOLrmplD6/AYKc87TCrp7JQrLVu0Slly+4Ci8tWYiE3MGTJGBhmPSTjLKIQ=="],
+
+    "@pkgs/pty-manager/@zenyr/bun-pty/@zenyr/bun-pty-darwin-x64": ["@zenyr/bun-pty-darwin-x64@0.4.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-tbssenRokNls193hCSywpDwH0IpYfx8FkiDtm6u7i2sphNw6ktGftzQHH/021pWjZNVdYA75YhlfZrIGdhjHow=="],
+
+    "@pkgs/pty-manager/@zenyr/bun-pty/@zenyr/bun-pty-linux-arm64": ["@zenyr/bun-pty-linux-arm64@0.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-kXTeEWZrjRn2jGGnxTrYnZSJ6ZRKTiR7otK7SlmVP+pa1OtZs5J77VG93/wWq2gpTAL7Bs4vNMjEj5A6UaJG7A=="],
+
+    "@pkgs/pty-manager/@zenyr/bun-pty/@zenyr/bun-pty-linux-x64": ["@zenyr/bun-pty-linux-x64@0.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Vlxkvlfcg8BWDvChvJbN4N3lG7z08f+24d2jvcfx/guRz5w1qjvHfMGWvGj2DtbzIBDjXO0CaKKzdN/T2ZxSqA=="],
+
+    "@pkgs/pty-manager/@zenyr/bun-pty/@zenyr/bun-pty-win32-x64": ["@zenyr/bun-pty-win32-x64@0.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-esZqEjPHPWRfAd/IZNaC4mptJ2HFdPXJQPUZVIdrwxEumL7NRoQZXVrlO7MRSO2Jrjqgna4IuQIvOKvCwJNMrg=="],
+
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "mcp-pty/@zenyr/bun-pty/@zenyr/bun-pty-darwin-arm64": ["@zenyr/bun-pty-darwin-arm64@0.4.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+tIBa2trf681O0ttftbarFEZuXOKOLrmplD6/AYKc87TCrp7JQrLVu0Slly+4Ci8tWYiE3MGTJGBhmPSTjLKIQ=="],
+
+    "mcp-pty/@zenyr/bun-pty/@zenyr/bun-pty-darwin-x64": ["@zenyr/bun-pty-darwin-x64@0.4.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-tbssenRokNls193hCSywpDwH0IpYfx8FkiDtm6u7i2sphNw6ktGftzQHH/021pWjZNVdYA75YhlfZrIGdhjHow=="],
+
+    "mcp-pty/@zenyr/bun-pty/@zenyr/bun-pty-linux-arm64": ["@zenyr/bun-pty-linux-arm64@0.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-kXTeEWZrjRn2jGGnxTrYnZSJ6ZRKTiR7otK7SlmVP+pa1OtZs5J77VG93/wWq2gpTAL7Bs4vNMjEj5A6UaJG7A=="],
+
+    "mcp-pty/@zenyr/bun-pty/@zenyr/bun-pty-linux-x64": ["@zenyr/bun-pty-linux-x64@0.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Vlxkvlfcg8BWDvChvJbN4N3lG7z08f+24d2jvcfx/guRz5w1qjvHfMGWvGj2DtbzIBDjXO0CaKKzdN/T2ZxSqA=="],
+
+    "mcp-pty/@zenyr/bun-pty/@zenyr/bun-pty-win32-x64": ["@zenyr/bun-pty-win32-x64@0.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-esZqEjPHPWRfAd/IZNaC4mptJ2HFdPXJQPUZVIdrwxEumL7NRoQZXVrlO7MRSO2Jrjqgna4IuQIvOKvCwJNMrg=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -19,7 +19,7 @@
     "@sindresorhus/is": "^7.1.0",
     "@xterm/addon-serialize": "^0.13.0",
     "@xterm/headless": "^5.5.0",
-    "@zenyr/bun-pty": "^0.4.3",
+    "@zenyr/bun-pty": "^0.4.4",
     "consola": "^3.4.2"
   }
 }

--- a/packages/mcp-pty/package.json
+++ b/packages/mcp-pty/package.json
@@ -47,7 +47,7 @@
     "@pkgs/pty-manager": "workspace:*",
     "@pkgs/session-manager": "workspace:*",
     "@xterm/headless": "^5.5.0",
-    "@zenyr/bun-pty": "^0.4.3",
+    "@zenyr/bun-pty": "^0.4.4",
     "consola": "^3.4.2",
     "fetch-to-node": "^2.1.0",
     "hono": "^4.9.10",

--- a/packages/mcp-pty/src/resources/index.ts
+++ b/packages/mcp-pty/src/resources/index.ts
@@ -123,36 +123,24 @@ export const createResourceHandlers = (server: McpServer) => {
 export const registerPtyResources = (server: McpServer): void => {
   const handlers = createResourceHandlers(server);
 
-  // Register global status resource (all sessions)
   server.registerResource(
     "status",
     "pty://status",
-    {
-      title: "Global Server Status",
-      description: "Server status including all sessions and process counts",
-    },
+    { title: "Server Status", description: "Session & process counts" },
     handlers.status,
   );
 
-  // Register processes resource (PTY process list)
   server.registerResource(
     "processes",
     "pty://processes",
-    {
-      title: "PTY Processes",
-      description: "List of PTY processes in current session",
-    },
+    { title: "Session Processes", description: "List running PTYs in session" },
     handlers.processes,
   );
 
-  // Register process output resource template (specific process output)
   server.registerResource(
     "process-output",
     new ResourceTemplate("pty://processes/{processId}", { list: undefined }),
-    {
-      title: "PTY Process Output",
-      description: "Output buffer for a specific PTY process",
-    },
+    { title: "Process Output", description: "Output buffer for PTY process" },
     handlers.processOutput,
   );
 };

--- a/packages/mcp-pty/src/tools/index.ts
+++ b/packages/mcp-pty/src/tools/index.ts
@@ -255,56 +255,52 @@ export const registerPtyTools = (server: McpServer): void => {
     {
       title: "Start PTY",
       description:
-        "Create new PTY instance and execute command. Supports interactive shells (bash/python/node), long-running processes (dev servers), TUI apps (vim/htop), and shell commands (ls/git). Returns processId for subsequent operations (write_input, read, kill) and initial screen output. Command runs in specified working directory (pwd). Use write_input to send input, read to get output, kill to terminate.",
+        "Create PTY, execute command, return processId & screen. Supports bash/python/node, dev servers, vim/htop, shell cmds. Use write_input for stdin, read for output, kill to terminate.",
       inputSchema: StartPtyInputSchema.shape,
       outputSchema: StartPtyOutputSchema.shape,
     },
     handlers.start,
   );
 
-  // Register kill tool
   server.registerTool(
     "kill",
     {
       title: "Kill PTY",
-      description: "Terminate PTY instance",
+      description: "Terminate PTY process",
       inputSchema: KillPtyInputSchema.shape,
       outputSchema: KillPtyOutputSchema.shape,
     },
     handlers.kill,
   );
 
-  // Register list tool
   server.registerTool(
     "list",
     {
-      title: "List PTY",
-      description: "List PTY processes",
+      title: "List PTYs",
+      description: "List running PTY processes in session",
       inputSchema: ListPtyInputSchema.shape,
       outputSchema: ListPtyOutputSchema.shape,
     },
     handlers.list,
   );
 
-  // Register read tool
   server.registerTool(
     "read",
     {
       title: "Read PTY",
-      description: "Read PTY output",
+      description: "Read PTY screen buffer",
       inputSchema: ReadPtyInputSchema.shape,
       outputSchema: ReadPtyOutputSchema.shape,
     },
     handlers.read,
   );
 
-  // Register write_input tool
   server.registerTool(
     "write_input",
     {
       title: "Write Input to PTY",
       description:
-        "Write input to PTY stdin and return terminal state. TWO MODES: (1) Safe mode [RECOMMENDED]: Use 'input' (plain text) + 'ctrlCode' (Enter/Escape/Ctrl+C) separately to avoid escape sequence confusion. Example: {input: 'print(2+2)', ctrlCode: 'Enter'}. (2) Raw mode: Use 'data' field for multiline text, ANSI codes, or binary data. Example: {data: 'line1\\nline2\\n'}. Modes are mutually exclusive.",
+        "Send input to PTY stdin, return screen state. Two modes: Safe (input + ctrlCode) or Raw (data). Ex: {input: 'ls', ctrlCode: 'Enter'} or {data: 'ls\\n'}. Windows SSH: use CRLF (\\r\\n) not LF.",
       inputSchema: WriteInputSchema.shape,
       outputSchema: WriteInputOutputSchema.shape,
     },

--- a/packages/pty-manager/package.json
+++ b/packages/pty-manager/package.json
@@ -14,7 +14,7 @@
     "@pkgs/logger": "workspace:*",
     "@pkgs/normalize-commands": "workspace:*",
     "@xterm/headless": "^5.5.0",
-    "@zenyr/bun-pty": "^0.4.3",
+    "@zenyr/bun-pty": "^0.4.4",
     "consola": "^3.4.2",
     "nanoid": "^5.1.6",
     "strip-ansi": "^7.1.2",


### PR DESCRIPTION
## Summary

- Upgrade @zenyr/bun-pty to 0.4.4 across all packages
- Document Windows SSH CRLF (\r\n) requirement in write_input tool
- Concisely rewrite all tool/resource descriptions (50-60% reduction)

## Details

**Issue**: Windows SSH interactive PTY sessions fail with LF-only line endings. Windows shells (cmd, PowerShell, bash) require CRLF.

**Solution**: Updated tool descriptions to clearly specify CRLF requirement for Windows SSH sessions, with practical examples.

**Changes**:
- Dependency: @zenyr/bun-pty 0.4.3 → 0.4.4
- Tools: Simplified descriptions, added Windows CRLF guidance
- Resources: Concise metadata with required information only
- Changelog: Documented fix and refactoring